### PR TITLE
Log monkey patching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 .tox
 build/
 dist/
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 *.egg-info/
 __pycache__
 .idea
+.cache
+.tox
+build/
+dist/
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 *.egg-info/
 __pycache__
 .idea
+.cache
+.tox
+build/
+dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,5 @@ python:
   - "3.6-dev" # 3.6 development branch
   - "3.7-dev" # 3.7 development branch
   - "nightly" # currently points to 3.7-dev
-install: pip3 install -r requirements.txt
-script:
-  - python setup.py test
+install: pip3 install -r requirements-dev.txt
+script: pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ python:
   - "3.6-dev" # 3.6 development branch
   - "3.7-dev" # 3.7 development branch
   - "nightly" # currently points to 3.7-dev
-install: pip install tox-travis
-script: tox
+install: pip3 install -r dev_requirements.txt
+script:
+  - python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ python:
   - "3.6-dev" # 3.6 development branch
   - "3.7-dev" # 3.7 development branch
   - "nightly" # currently points to 3.7-dev
-install: pip3 install -r dev_requirements.txt
+install: pip3 install -r requirements.txt
 script:
   - python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+sudo: false
+python:
+  - "3.6"
+  - "3.6-dev" # 3.6 development branch
+  - "3.7-dev" # 3.7 development branch
+  - "nightly" # currently points to 3.7-dev
+install: pip install tox-travis
+script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+sudo: false
+python:
+  - "3.6"
+  - "3.6-dev" # 3.6 development branch
+  - "3.7-dev" # 3.7 development branch
+  - "nightly" # currently points to 3.7-dev
+install: pip3 install -r requirements.txt
+script:
+  - python setup.py test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.3.0
+*2017-10-18*
+
+- Monkey patching function logs the changes being applied and list them when calling `monkey_patch.list_patches()`, allowing for an optional description
+
+
 ## 1.2.0
 *2017-09-21*
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mara App
 
-[![Build Status](https://travis-ci.org/mara/mara-app.svg?branch=log-monkey-patching)](https://travis-ci.org/mara/mara-app)
+[![Build Status](https://travis-ci.org/mara/mara-app.svg?branch=master)](https://travis-ci.org/mara/mara-app)
 
 A flask app for building backends that are distributed across separate packages. Provides 
 - a Bootstrap 4 based page layout 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Mara App
 
+[![Build Status](https://travis-ci.org/mara/mara-app.svg?branch=master)](https://travis-ci.org/mara/mara-app)
+
 A flask app for building backends that are distributed across separate packages. Provides 
 - a Bootstrap 4 based page layout 
 - auto-detection of flask blueprints

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Mara App
 
+[![Build Status](https://travis-ci.org/mara/mara-app.svg?branch=log-monkey-patching)](https://travis-ci.org/mara/mara-app)
+
 A flask app for building backends that are distributed across separate packages. Provides 
 - a Bootstrap 4 based page layout 
 - auto-detection of flask blueprints

--- a/mara_app/app.py
+++ b/mara_app/app.py
@@ -110,4 +110,3 @@ class MaraApp(flask.Flask):
         original_url_for = flask.url_for
         flask.url_for = functools.lru_cache(maxsize=None)(original_url_for)
 
-

--- a/mara_app/app.py
+++ b/mara_app/app.py
@@ -109,3 +109,5 @@ class MaraApp(flask.Flask):
         https://stackoverflow.com/questions/16713644/why-is-flask-url-for-too-slow"""
         original_url_for = flask.url_for
         flask.url_for = functools.lru_cache(maxsize=None)(original_url_for)
+
+

--- a/mara_app/app.py
+++ b/mara_app/app.py
@@ -109,3 +109,4 @@ class MaraApp(flask.Flask):
         https://stackoverflow.com/questions/16713644/why-is-flask-url-for-too-slow"""
         original_url_for = flask.url_for
         flask.url_for = functools.lru_cache(maxsize=None)(original_url_for)
+

--- a/mara_app/app.py
+++ b/mara_app/app.py
@@ -109,4 +109,3 @@ class MaraApp(flask.Flask):
         https://stackoverflow.com/questions/16713644/why-is-flask-url-for-too-slow"""
         original_url_for = flask.url_for
         flask.url_for = functools.lru_cache(maxsize=None)(original_url_for)
-

--- a/mara_app/cli.py
+++ b/mara_app/cli.py
@@ -1,6 +1,8 @@
 """Mara admin command line interface"""
 
-import click, sys
+import sys
+
+import click
 from mara_app import migrations
 from mara_db import dbs
 import mara_db.config

--- a/mara_app/config.py
+++ b/mara_app/config.py
@@ -4,7 +4,7 @@ import flask
 from mara_page import navigation
 
 
-def flask_config() -> {str:str}:
+def flask_config() -> {str: str}:
     """
     Settings for the flask App.
     See http://flask.pocoo.org/docs/latest/config/#builtin-configuration-values for values and their defaults

--- a/mara_app/layout.py
+++ b/mara_app/layout.py
@@ -80,8 +80,9 @@ def page_header(response: mara_page.response.Response):
 def action_button(button: mara_page.response.ActionButton):
     """Renders an action button"""
     return [_.a(class_='btn', href=button.action, title=button.title)[
-                _.span(class_='fa fa-' + button.icon)[''], ' ',
-                button.label]]
+            _.span(class_='fa fa-' + button.icon)[''], ' ',
+            button.label]]
+
 
 @functools.lru_cache(maxsize=None)
 def navigation_bar() -> str:
@@ -127,7 +128,6 @@ def flash_messages(response: mara_page.response.Response) -> xml.XMLElement:
                 map(lambda m: 'showAlert("' + m[1].replace('"', '&quot;') + '","' + (
                     m[0] if m[0] != 'message' else 'info') + '");',
                     flask.get_flashed_messages(True))
-
             ]]
 
 

--- a/mara_app/migrations.py
+++ b/mara_app/migrations.py
@@ -49,7 +49,8 @@ def get_migration_ddl(engine: sqlalchemy.engine.Engine) -> [str]:
             # Step 2: autogenerate a python statement from the operation, e.g. "executor.drop_table('bar')"
             renderer = alembic.autogenerate.renderers.dispatch(operation)
             statement = renderer(autogen_context, operation)
-            if isinstance(statement, list): statement = statement[0]
+            if isinstance(statement, list):
+                statement = statement[0]
 
             # Step 3: "execute" python statement and get sql from buffer, e.g. "DROP TABLE bar;"
             eval(statement)

--- a/mara_app/monkey_patch.py
+++ b/mara_app/monkey_patch.py
@@ -1,7 +1,7 @@
 """
 Functions for monkey patching functions in other modules. See https://en.wikipedia.org/wiki/Monkey_patch
 
-There are other excellent libraries for this, which unfortunately don't excactly match our use case:
+There are other excellent libraries for this, which unfortunately don't exactly match our use case:
 
 - https://github.com/christophercrouzet/gorilla
 - https://github.com/iki/monkeypatch
@@ -9,19 +9,27 @@ There are other excellent libraries for this, which unfortunately don't excactly
 - https://bitbucket.org/schesis/ook
 """
 
-import collections
 import functools
 import inspect
 import logging
 import sys
 import typing
 
+
 # list of applied patches, used to later generate a 'report' of them
-Patch = collections.namedtuple('Patch', 'replaces original_module original_name description patcher_frame')
+class Patch(typing.NamedTuple):
+    replaces: bool
+    original_module: str
+    original_name: str
+    description: str
+    patcher_frame: typing.Any
+
+
 __applied_patches = []
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
+
 
 def patch(original_function: typing.Callable, patch_description: str = '') -> typing.Callable:
     """
@@ -51,7 +59,8 @@ def patch(original_function: typing.Callable, patch_description: str = '') -> ty
     Returns: The replaced function
     """
     logger.warning(
-        f'function {original_function.__module__}.{original_function.__name__} is being replaced (change: {patch_description})')
+        f'function {original_function.__module__}.{original_function.__name__}'
+        f'is being replaced (change: {patch_description})')
     __applied_patches.append(Patch(replaces=True,
                                    original_module=original_function.__module__,
                                    original_name=original_function.__name__,
@@ -98,7 +107,8 @@ def wrap(original_function: typing.Callable, wrap_description: str = '') -> typi
     Returns: The wrapped function
     """
     logger.warning(
-        f'function {original_function.__module__}.{original_function.__name__} is being wrapped (change: {wrap_description})')
+        f'function {original_function.__module__}.{original_function.__name__}'
+        f'is being wrapped (change: {wrap_description})')
     __applied_patches.append(Patch(replaces=False,
                                    original_module=original_function.__module__,
                                    original_name=original_function.__name__,
@@ -134,4 +144,3 @@ def list_patches():
     :return:
     """
     return __applied_patches
-

--- a/mara_app/monkey_patch.py
+++ b/mara_app/monkey_patch.py
@@ -51,7 +51,7 @@ def patch(original_function: typing.Callable, patch_description: str = '') -> ty
     Returns: The replaced function
     """
     logger.warning(
-        f'function {original_function.__module__}.{original_function.__name__} is being replaced (change: {patch_description})'.)
+        f'function {original_function.__module__}.{original_function.__name__} is being replaced (change: {patch_description})')
     __applied_patches.append(Patch(replaces=True,
                                    original_module=original_function.__module__,
                                    original_name=original_function.__name__,

--- a/mara_app/monkey_patch.py
+++ b/mara_app/monkey_patch.py
@@ -9,12 +9,22 @@ There are other excellent libraries for this, which unfortunately don't excactly
 - https://bitbucket.org/schesis/ook
 """
 
+import collections
 import functools
+import inspect
+import logging
 import sys
 import typing
 
+# list of applied patches, used to later generate a 'report' of them
+Patch = collections.namedtuple('Patch', 'replaces original_module original_name description patcher_frame')
+__applied_patches = []
 
-def patch(original_function: typing.Callable) -> typing.Callable:
+logging.basicConfig(level=logging.INFO,
+                    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+
+def patch(original_function: typing.Callable, patch_description: str = '') -> typing.Callable:
     """
     A decorator for replacing a function in another module
 
@@ -41,6 +51,14 @@ def patch(original_function: typing.Callable) -> typing.Callable:
 
     Returns: The replaced function
     """
+    logging.info(
+        'function {}.{} is being replaced (change: {})'.format(original_function.__module__, original_function.__name__,
+                                                              patch_description))
+    __applied_patches.append(Patch(replaces=True,
+                                   original_module=original_function.__module__,
+                                   original_name=original_function.__name__,
+                                   description=patch_description,
+                                   patcher_frame=inspect.stack()[0]))
 
     def decorator(new_function):
         if not isinstance(original_function, typing.Callable):
@@ -56,7 +74,7 @@ def patch(original_function: typing.Callable) -> typing.Callable:
     return decorator
 
 
-def wrap(original_function: typing.Callable) -> typing.Callable:
+def wrap(original_function: typing.Callable, wrap_description: str = '') -> typing.Callable:
     """
     A decorator for wrapping a function in another module
 
@@ -77,21 +95,29 @@ def wrap(original_function: typing.Callable) -> typing.Callable:
 
     Args:
         original_function: The function or method to wrap
+        patch_description (optional): The description of the patch
 
     Returns: The wrapped function
     """
+    logging.info(
+        'function {}.{} is being wrapped (change: {})'.format(original_function.__module__, original_function.__name__,
+                                                              wrap_description))
+    __applied_patches.append(Patch(replaces=False,
+                                   original_module=original_function.__module__,
+                                   original_name=original_function.__name__,
+                                   description=wrap_description,
+                                   patcher_frame=inspect.stack()[0]))
 
     def decorator(new_function):
         if not isinstance(original_function, typing.Callable):
             raise TypeError("Argument passed to @wrap decorator must be a Callable")
 
-        # supply orginal_function as first argument to new_function
+        # supply original_function as first argument to new_function
         def wrapper(*args, **kwargs):
             return new_function(original_function, *args, **kwargs)
 
         # copy properties such as __doc__, __module__ from original_function to the wrapper
         functools.update_wrapper(wrapper, original_function)
-
 
         # replace function
         setattr(sys.modules[original_function.__module__], original_function.__name__, wrapper)
@@ -99,3 +125,15 @@ def wrap(original_function: typing.Callable) -> typing.Callable:
 
     return decorator
 
+
+def list_patches():
+    """
+    List the applied patches, for each one gives a named tuple containing:
+     - whether the function was replaced or wrapped
+     - name of the module containing the patched function
+     - name of the patched function
+     - the provided reason for the patch, if any
+     - the frame of the caller
+    :return:
+    """
+    return __applied_patches

--- a/mara_app/monkey_patch.py
+++ b/mara_app/monkey_patch.py
@@ -134,3 +134,4 @@ def list_patches():
     :return:
     """
     return __applied_patches
+

--- a/mara_app/monkey_patch.py
+++ b/mara_app/monkey_patch.py
@@ -51,8 +51,7 @@ def patch(original_function: typing.Callable, patch_description: str = '') -> ty
     Returns: The replaced function
     """
     logger.warning(
-        'function {}.{} is being replaced (change: {})'.format(original_function.__module__, original_function.__name__,
-                                                              patch_description))
+        f'function {original_function.__module__}.{original_function.__name__} is being replaced (change: {patch_description})'.)
     __applied_patches.append(Patch(replaces=True,
                                    original_module=original_function.__module__,
                                    original_name=original_function.__name__,
@@ -99,8 +98,7 @@ def wrap(original_function: typing.Callable, wrap_description: str = '') -> typi
     Returns: The wrapped function
     """
     logger.warning(
-        'function {}.{} is being wrapped (change: {})'.format(original_function.__module__, original_function.__name__,
-                                                              wrap_description))
+        f'function {original_function.__module__}.{original_function.__name__} is being wrapped (change: {wrap_description})')
     __applied_patches.append(Patch(replaces=False,
                                    original_module=original_function.__module__,
                                    original_name=original_function.__name__,

--- a/mara_app/monkey_patch.py
+++ b/mara_app/monkey_patch.py
@@ -20,8 +20,7 @@ import typing
 Patch = collections.namedtuple('Patch', 'replaces original_module original_name description patcher_frame')
 __applied_patches = []
 
-logging.basicConfig(level=logging.INFO,
-                    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
 
 
 def patch(original_function: typing.Callable, patch_description: str = '') -> typing.Callable:
@@ -51,7 +50,7 @@ def patch(original_function: typing.Callable, patch_description: str = '') -> ty
 
     Returns: The replaced function
     """
-    logging.info(
+    logger.warn(
         'function {}.{} is being replaced (change: {})'.format(original_function.__module__, original_function.__name__,
                                                               patch_description))
     __applied_patches.append(Patch(replaces=True,
@@ -99,7 +98,7 @@ def wrap(original_function: typing.Callable, wrap_description: str = '') -> typi
 
     Returns: The wrapped function
     """
-    logging.info(
+    logger.warn(
         'function {}.{} is being wrapped (change: {})'.format(original_function.__module__, original_function.__name__,
                                                               wrap_description))
     __applied_patches.append(Patch(replaces=False,

--- a/mara_app/monkey_patch.py
+++ b/mara_app/monkey_patch.py
@@ -21,7 +21,7 @@ Patch = collections.namedtuple('Patch', 'replaces original_module original_name 
 __applied_patches = []
 
 logger = logging.getLogger(__name__)
-
+logger.setLevel(logging.INFO)
 
 def patch(original_function: typing.Callable, patch_description: str = '') -> typing.Callable:
     """
@@ -50,7 +50,7 @@ def patch(original_function: typing.Callable, patch_description: str = '') -> ty
 
     Returns: The replaced function
     """
-    logger.warn(
+    logger.warning(
         'function {}.{} is being replaced (change: {})'.format(original_function.__module__, original_function.__name__,
                                                               patch_description))
     __applied_patches.append(Patch(replaces=True,
@@ -98,7 +98,7 @@ def wrap(original_function: typing.Callable, wrap_description: str = '') -> typi
 
     Returns: The wrapped function
     """
-    logger.warn(
+    logger.warning(
         'function {}.{} is being wrapped (change: {})'.format(original_function.__module__, original_function.__name__,
                                                               wrap_description))
     __applied_patches.append(Patch(replaces=False,

--- a/mara_app/views.py
+++ b/mara_app/views.py
@@ -1,19 +1,22 @@
 """Mara admin views"""
 
+import copy
 import html
 import inspect
-import pathlib
 import pprint
 import sys
-import copy
+import types
+import typing
 
-import flask, typing, types
+import flask
+
 from mara_page import acl
 from mara_page import navigation, response, _, bootstrap
 
 blueprint = flask.Blueprint('mara_app', __name__, url_prefix='/admin', static_folder='static')
 
 acl_resource = acl.AclResource('Configuration')
+
 
 @blueprint.route('/configuration')
 @acl.require_permission(acl_resource)

--- a/mara_app/views.py
+++ b/mara_app/views.py
@@ -15,7 +15,6 @@ blueprint = flask.Blueprint('mara_app', __name__, url_prefix='/admin', static_fo
 
 acl_resource = acl.AclResource('Configuration')
 
-
 @blueprint.route('/configuration')
 @acl.require_permission(acl_resource)
 def configuration_page():

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 -e git+https://github.com/mara/mara-db.git#egg=mara-db
 -e git+https://github.com/mara/mara-page.git#egg=mara-page
 Flask==0.12.2
-pytest-runner
+alembic>=0.8.10

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@
 -e git+https://github.com/mara/mara-page.git#egg=mara-page
 Flask==0.12.2
 alembic>=0.8.10
+sqlalchemy_utils>=0.32.19

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+-e git+https://github.com/mara/mara-db.git#egg=mara-db
+-e git+https://github.com/mara/mara-page.git#egg=mara-page
+Flask==0.12.2
+pytest-runner

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 -e git+https://github.com/mara/mara-db.git#egg=mara-db
 -e git+https://github.com/mara/mara-page.git#egg=mara-page
-Flask==0.11.1
-
+Flask==0.12.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+-e git+git@github.com:mara/mara-db.git@master#egg=mara-db
+-e git+git@github.com:mara/mara-page.git@master#egg=mara-page

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 -e git+https://github.com/mara/mara-db.git#egg=mara-db
 -e git+https://github.com/mara/mara-page.git#egg=mara-page
-Flask==0.12.2
+Flask

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
--e git+git@github.com:mara/mara-db.git@master#egg=mara-db
--e git+git@github.com:mara/mara-page.git@master#egg=mara-page
+-e git+https://github.com/mara/mara-db.git#egg=mara-db
+-e git+https://github.com/mara/mara-page.git#egg=mara-page

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+-e git+https://github.com/mara/mara-db.git#egg=mara-db
+-e git+https://github.com/mara/mara-page.git#egg=mara-page
+Flask==0.12.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 -e git+https://github.com/mara/mara-db.git#egg=mara-db
 -e git+https://github.com/mara/mara-page.git#egg=mara-page
-Flask
+Flask==0.11.1
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 -e git+https://github.com/mara/mara-db.git#egg=mara-db
 -e git+https://github.com/mara/mara-page.git#egg=mara-page
+Flask==0.12.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+; suggested at https://docs.pytest.org/en/latest/goodpractices.html
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -2,28 +2,24 @@ from setuptools import setup, find_packages
 
 setup(
     name='mara-app',
-    version='1.2.0',
+    version='1.3.0',
 
     description="Framework for distributing flask apps across separate packages with minimal dependencies",
 
     install_requires=[
         'mara-page>=1.2.0',
-        'mara-db>=1.0.0',
+        'mara-db>=1.0.1',
         'flask>=0.12',
         'alembic>=0.8.10',
         'sqlalchemy-utils>=0.32.14'
     ],
-
-    dependency_links=[
-        'https://github.com/mara/mara-page.git@ui-improvements#egg=mara-page'
-        'https://github.com/mara/mara-db.git@1.0.0#egg=mara-db'
-    ],
-
     packages=find_packages(),
 
     author='Mara contributors',
     license='MIT',
 
     entry_points={
-    }
+    },
+    python_requires='>=3.6'
+
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mara-app',
-    version='1.2.0',
+    version='1.3.0',
 
     description="Framework for distributing flask apps across separate packages with minimal dependencies",
 
@@ -15,7 +15,7 @@ setup(
     ],
 
     dependency_links=[
-        'https://github.com/mara/mara-page.git@ui-improvements#egg=mara-page'
+        'https://github.com/mara/mara-page.git@master#egg=mara-page'
         'https://github.com/mara/mara-db.git@1.0.0#egg=mara-db'
     ],
 
@@ -25,5 +25,7 @@ setup(
     license='MIT',
 
     entry_points={
-    }
+    },
+    python_requires='>=3.6'
+
 )

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
         'alembic>=0.8.10',
         'sqlalchemy-utils>=0.32.14'
     ],
+    tests_require=['pytest'],
     packages=find_packages(),
 
     author='Mara contributors',

--- a/setup.py
+++ b/setup.py
@@ -13,12 +13,6 @@ setup(
         'alembic>=0.8.10',
         'sqlalchemy-utils>=0.32.14'
     ],
-
-    dependency_links=[
-        'http://github.com/mara/mara-page/tarball/master#egg=mara-page-1.2.0',
-        'http://github.com/mara/mara-db/tarball/master#egg=mara-db-1.0.1'
-    ],
-
     packages=find_packages(),
 
     author='Mara contributors',

--- a/setup.py
+++ b/setup.py
@@ -8,15 +8,15 @@ setup(
 
     install_requires=[
         'mara-page>=1.2.0',
-        'mara-db>=1.0.0',
+        'mara-db>=1.0.1',
         'flask>=0.12',
         'alembic>=0.8.10',
         'sqlalchemy-utils>=0.32.14'
     ],
 
     dependency_links=[
-        'https://github.com/mara/mara-page.git@master#egg=mara-page'
-        'https://github.com/mara/mara-db.git@1.0.0#egg=mara-db'
+        'http://github.com/mara/mara-page/tarball/master#egg=mara-page-1.2.0',
+        'http://github.com/mara/mara-db/tarball/master#egg=mara-db-1.0.1'
     ],
 
     packages=find_packages(),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,12 +1,13 @@
-import unittest
+import pytest
 
 from mara_app.app import MaraApp
 from mara_app import monkey_patch
 from tests import wrap_target
 
 
-class AppTest(unittest.TestCase):
-    def setUp(self):
+class TestApp:
+    @pytest.fixture(autouse=True)
+    def set_up(self):
         app = MaraApp()
         self.app = app.test_client()
 
@@ -14,36 +15,34 @@ class AppTest(unittest.TestCase):
     def wrapper(a: int):
         return a + 100
 
-
     @monkey_patch.wrap(wrap_target.multiply_by_three, 'test the monkey patch tracking for wrap')
     def wrapper(original_fn, a: int):
         return original_fn(a) + 1000
 
     def test_config_page_exists(self):
         response = self.app.get("/admin/configuration")
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
     def test_patch_is_listed(self):
         patches = monkey_patch.list_patches()
-        self.assertEqual(len(patches), 2)
+        assert len(patches) == 2
         # NOTE: the list follow the same order of patch/wrapping
-        self.assertEqual(patches[0].original_module, 'tests.wrap_target')
-        self.assertEqual(patches[0].original_name, 'multiply_by_two')
-        self.assertEqual(patches[0].description, 'test the monkey patch tracking for patch')
-        self.assertTrue(patches[0].replaces)
+        assert patches[0].original_module == 'tests.wrap_target'
+        assert patches[0].original_name == 'multiply_by_two'
+        assert patches[0].description == 'test the monkey patch tracking for patch'
+        assert patches[0].replaces
 
-        self.assertEqual(patches[1].original_module, 'tests.wrap_target')
-        self.assertEqual(patches[1].original_name, 'multiply_by_three')
-        self.assertEqual(patches[1].description, 'test the monkey patch tracking for wrap')
-        self.assertFalse(patches[1].replaces)
+        assert patches[1].original_module == 'tests.wrap_target'
+        assert patches[1].original_name == 'multiply_by_three'
+        assert patches[1].description == 'test the monkey patch tracking for wrap'
+        assert not patches[1].replaces
 
     def test_patches_are_actually_applied(self):
         # this has been replaced, it does add 100
-        self.assertEqual(wrap_target.multiply_by_two(1), 101)
+        assert wrap_target.multiply_by_two(1) == 101
         # this has been wrapped, it does multiply by 3 AND add 1000
-        self.assertEqual(wrap_target.multiply_by_three(1), 1003)
-
+        assert wrap_target.multiply_by_three(1) == 1003
 
 
 if __name__ == "__main__":
-    unittest.main()
+    pytest.main()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,18 @@
+import unittest
+
+from flask import Flask
+
+from mara_app import MaraApp
+
+
+class AppTest(unittest.TestCase):
+    def setUp(self):
+        app = MaraApp()
+        self.app = app.test_client()
+
+    def test_correct_call(self):
+        self.assertEqual(1, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,49 @@
+import unittest
+
+from mara_app.app import MaraApp
+from mara_app import monkey_patch
+from tests import wrap_target
+
+
+class AppTest(unittest.TestCase):
+    def setUp(self):
+        app = MaraApp()
+        self.app = app.test_client()
+
+    @monkey_patch.patch(wrap_target.multiply_by_two, 'test the monkey patch tracking for patch')
+    def wrapper(a: int):
+        return a + 100
+
+
+    @monkey_patch.wrap(wrap_target.multiply_by_three, 'test the monkey patch tracking for wrap')
+    def wrapper(original_fn, a: int):
+        return original_fn(a) + 1000
+
+    def test_config_page_exists(self):
+        response = self.app.get("/admin/configuration")
+        self.assertEqual(response.status_code, 200)
+
+    def test_patch_is_listed(self):
+        patches = monkey_patch.list_patches()
+        self.assertEqual(len(patches), 2)
+        # NOTE: the list follow the same order of patch/wrapping
+        self.assertEqual(patches[0].original_module, 'tests.wrap_target')
+        self.assertEqual(patches[0].original_name, 'multiply_by_two')
+        self.assertEqual(patches[0].description, 'test the monkey patch tracking for patch')
+        self.assertTrue(patches[0].replaces)
+
+        self.assertEqual(patches[1].original_module, 'tests.wrap_target')
+        self.assertEqual(patches[1].original_name, 'multiply_by_three')
+        self.assertEqual(patches[1].description, 'test the monkey patch tracking for wrap')
+        self.assertFalse(patches[1].replaces)
+
+    def test_patches_are_actually_applied(self):
+        # this has been replaced, it does add 100
+        self.assertEqual(wrap_target.multiply_by_two(1), 101)
+        # this has been wrapped, it does multiply by 3 AND add 1000
+        self.assertEqual(wrap_target.multiply_by_three(1), 1003)
+
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,8 +1,8 @@
 import unittest
 
-from flask import Flask
-
 from mara_app.app import MaraApp
+from mara_app import monkey_patch
+from tests import wrap_target
 
 
 class AppTest(unittest.TestCase):
@@ -10,8 +10,39 @@ class AppTest(unittest.TestCase):
         app = MaraApp()
         self.app = app.test_client()
 
-    def test_correct_call(self):
-        self.assertEqual(1, 1)
+    @monkey_patch.patch(wrap_target.multiply_by_two, 'test the monkey patch tracking for patch')
+    def wrapper(a: int):
+        return a + 100
+
+
+    @monkey_patch.wrap(wrap_target.multiply_by_three, 'test the monkey patch tracking for wrap')
+    def wrapper(original_fn, a: int):
+        return original_fn(a) + 1000
+
+    def test_config_page_exists(self):
+        response = self.app.get("/admin/configuration")
+        self.assertEqual(response.status_code, 200)
+
+    def test_patch_is_listed(self):
+        patches = monkey_patch.list_patches()
+        self.assertEqual(len(patches), 2)
+        # NOTE: the list follow the same order of patch/wrapping
+        self.assertEqual(patches[0].original_module, 'tests.wrap_target')
+        self.assertEqual(patches[0].original_name, 'multiply_by_two')
+        self.assertEqual(patches[0].description, 'test the monkey patch tracking for patch')
+        self.assertTrue(patches[0].replaces)
+
+        self.assertEqual(patches[1].original_module, 'tests.wrap_target')
+        self.assertEqual(patches[1].original_name, 'multiply_by_three')
+        self.assertEqual(patches[1].description, 'test the monkey patch tracking for wrap')
+        self.assertFalse(patches[1].replaces)
+
+    def test_patches_are_actually_applied(self):
+        # this has been replaced, it does add 100
+        self.assertEqual(wrap_target.multiply_by_two(1), 101)
+        # this has been wrapped, it does multiply by 3 AND add 1000
+        self.assertEqual(wrap_target.multiply_by_three(1), 1003)
+
 
 
 if __name__ == "__main__":

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,7 +2,7 @@ import unittest
 
 from flask import Flask
 
-from mara_app import MaraApp
+from mara_app.app import MaraApp
 
 
 class AppTest(unittest.TestCase):

--- a/tests/wrap_target.py
+++ b/tests/wrap_target.py
@@ -1,0 +1,6 @@
+def multiply_by_two(a: int) -> int:
+    return a * 2
+
+
+def multiply_by_three(a: int) -> int:
+    return a * 3

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,4 @@
+[testenv]
+commands=pytest
+setenv =
+    PYTHONPATH = {toxinidir}

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [testenv]
+deps= -r{toxinidir}/requirements.txt
 commands=pytest
 setenv =
     PYTHONPATH = {toxinidir}

--- a/tox.ini
+++ b/tox.ini
@@ -2,4 +2,4 @@
 deps= -r{toxinidir}/requirements.txt
 commands=pytest
 setenv =
-    PYTHONPATH = {toxinidir}
+    PYTHONPATH = 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,0 @@
-[testenv]
-deps= -r{toxinidir}/requirements.txt
-commands=pytest
-setenv =
-    PYTHONPATH = 


### PR DESCRIPTION
Not ready yet, PR opened for comments before writing tests and bumping the version.

Two issues:

1. should we keep it compatible with Python 3.5 ? Python 3.6 added, among others, typing for lists and named tuples which can be used here. `setup.py` does not specify a version, I'd add it there too.

2.logging: I used a module-level logger but the default in Python is to not show a timestamp, which is not that useful for a web app/ETL, maybe we should put a `logging.setConfig()` in the package to use a better format
