### PR TITLE
Don't hardcode navigation-bar endpoint

### DIFF
--- a/mara_app/layout.py
+++ b/mara_app/layout.py
@@ -39,7 +39,9 @@ def body_elements(response: mara_page.response.Response) -> [xml.XMLElement]:
     """All elements inside the body section of the html page"""
     return [
         _.script['var isTouchDevice = ("ontouchstart" in document.documentElement); ',
-                 'window.document.getElementsByTagName("body")[0].className += isTouchDevice ? " touch" : " no-touch";'],
+                 'window.document.getElementsByTagName("body")[0].className += isTouchDevice ? " touch" : " no-touch";',
+                 f"var navigationUrl = '{flask.url_for('mara_app.navigation_bar')}';"
+        ],
         page_header(response),
         navigation_bar(),
         content_area(response),

--- a/mara_app/static/mara.js
+++ b/mara_app/static/mara.js
@@ -4,8 +4,8 @@ $(document).ready(function () {
         $('#mara-navigation').mouseleave(collapseNavigation);
     }
 
-    var navigationUrl = '/mara-app/navigation-bar';
     $.ajax({
+        // navigationUrl is set in layout.py
         url: navigationUrl,
         success: function (navigationEntries) {
             $('#mara-navigation').empty().append(navigationEntries).fadeIn(500);


### PR DESCRIPTION
This makes the the whole MaraApp mountable under a subfolder with werkzeug.wsgi.DispatcherMiddleware.

```python
if wsgi_url_prefix() != '':
    from werkzeug.wsgi import DispatcherMiddleware

    app.config["APPLICATION_ROOT"] = wsgi_url_prefix()
    app.wsgi_app = DispatcherMiddleware(
        # Load a dummy app at the root URL to give 404 errors.
        Flask('dummy_app'),
        # Serve the real app at APPLICATION_ROOT.
        {
            app.config['APPLICATION_ROOT']: app.wsgi_app,
        }
    )
```