### PR TITLE
Improve loading speed of navigation entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.2.0 (2020-07-03)
+
+- Improve loading speed of navigation entries
+
+
 ## 2.1.3 (2020-07-01)
 
 - Always upgrade packages used in makefile to latest version (#29)

--- a/mara_app/views.py
+++ b/mara_app/views.py
@@ -88,7 +88,7 @@ def package_configs_navigation_entry():
                 label=module_name, icon='list', description=config['doc'],
                 uri_fn=lambda _module_name=module_name: flask.url_for('mara_app.configuration_page',
                                                                       _anchor=_module_name))
-            for module_name, config in sorted(_config_modules().items())]
+            for module_name, config in sorted(_config_modules(with_functions=False).items())]
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def get_long_description():
 
 setup(
     name='mara-app',
-    version='2.1.3',
+    version='2.2.0',
 
     description="Framework for distributing flask apps across separate packages with minimal dependencies",
 


### PR DESCRIPTION
Loading the navigation tree was pretty slow for quite some. Today profiled the `mara_app.app.combine_navigation_entries` and found this circular call: 

![image](https://user-images.githubusercontent.com/1379194/86480818-0dcfa700-bd4f-11ea-854c-4942568f4b80.png)

Still don't know why it didn't stackoverlow.