### PR TITLE
add CI test for python 3.6

### DIFF
--- a/.github/workflows/build_for_deployment.yaml
+++ b/.github/workflows/build_for_deployment.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
     steps:
       - name: Chechout code
         uses: actions/checkout@v2


### PR DESCRIPTION
Adds a CI test for python 3.6 since the [setup.py](https://github.com/mara/mara-app/blob/master/setup.py) file still supports python 3.6